### PR TITLE
Datngo/recipes list/navigate to details

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation 'androidx.compose.material:material:1.3.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
     implementation "androidx.navigation:navigation-compose:2.4.0-rc01"
+    implementation "io.coil-kt:coil-compose:1.4.0"
 
     // Coroutines
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'

--- a/app/src/main/java/com/example/myrecipes/modelview/RecipesListViewModel.kt
+++ b/app/src/main/java/com/example/myrecipes/modelview/RecipesListViewModel.kt
@@ -23,7 +23,8 @@ import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
 import java.util.logging.Logger
 
-class RecipesListViewModel(application: Application, private val workManager: WorkManager) : AndroidViewModel(application) {
+class RecipesListViewModel(application: Application, private val workManager: WorkManager) :
+    AndroidViewModel(application) {
     private val recipeApi: RecipesApiRequest = RecipesApiRequest()
     private val logger = Logger.getLogger("MyLogger")
 
@@ -64,11 +65,13 @@ class RecipesListViewModel(application: Application, private val workManager: Wo
         initalRecipesFetching()
         repository = RecipesRepository(application.applicationContext)
     }
+
     private fun convertJsonToProducts(json: String?): List<Recipe> {
         val listType = object : TypeToken<List<Recipe>>() {}.type
         return Gson().fromJson(json, listType)
     }
-    private fun initalRecipesFetching(){
+
+    private fun initalRecipesFetching() {
         val refreshWorkRequest: WorkRequest =
             OneTimeWorkRequestBuilder<RefreshRecipesWorker>()
                 .setConstraints(constraints)
@@ -83,26 +86,33 @@ class RecipesListViewModel(application: Application, private val workManager: Wo
                         val outputData = workInfo.outputData
                         val productsJson = outputData.getString("Recipes")
 
-                        if (productsJson != null){
+                        if (productsJson != null) {
                             val recipes: List<Recipe> = convertJsonToProducts(productsJson)
                             _loading.value = false
                             _recipes.value = recipes
                             _error.value = false
                         }
                     }
+
                     WorkInfo.State.FAILED -> {
                         logger.warning("Work request failed")
                         _error.value = true
                     }
+
                     WorkInfo.State.CANCELLED -> {
                         logger.warning("Work request cancelled")
                     }
+
                     else -> {
                         // Work request is still running or enqueued
                     }
                 }
             }
         }
+    }
+
+    fun getRecipeById(recipeId: String): Recipe? {
+        return recipes.value.firstOrNull { it.idMeal == recipeId}
     }
 
 }

--- a/app/src/main/java/com/example/myrecipes/view/UI/Home.kt
+++ b/app/src/main/java/com/example/myrecipes/view/UI/Home.kt
@@ -42,7 +42,7 @@ fun Home(modelViewModel: RecipesListViewModel, navController: NavHostController)
 
         Button(
             onClick = {
-                navController.navigate(Screen.SIGNUP.name)
+                navController.navigate(Screen.SIGNUP.route)
             },
             modifier = Modifier.padding(vertical = 8.dp)
         ) {
@@ -51,7 +51,7 @@ fun Home(modelViewModel: RecipesListViewModel, navController: NavHostController)
 
         Button(
             onClick = {
-                navController.navigate(Screen.LOGIN.name)
+                navController.navigate(Screen.LOGIN.route)
             },
             modifier = Modifier.padding(vertical = 8.dp)
         ) {
@@ -60,7 +60,7 @@ fun Home(modelViewModel: RecipesListViewModel, navController: NavHostController)
 
         Button(
             onClick = {
-                navController.navigate(Screen.RECIPE_LIST.name)
+                navController.navigate(Screen.RECIPE_LIST.route)
             },
             modifier = Modifier.padding(vertical = 8.dp)
         ) {
@@ -70,7 +70,7 @@ fun Home(modelViewModel: RecipesListViewModel, navController: NavHostController)
 
         Button(
             onClick = {
-                navController.navigate(Screen.RECIPE_DETAIL.name)
+                navController.navigate(Screen.RECIPE_DETAIL.route)
             },
             modifier = Modifier.padding(vertical = 8.dp)
         ) {

--- a/app/src/main/java/com/example/myrecipes/view/UI/RecipeDetail.kt
+++ b/app/src/main/java/com/example/myrecipes/view/UI/RecipeDetail.kt
@@ -12,38 +12,57 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.rememberImagePainter
 import com.example.myrecipes.modelview.RecipesListViewModel
 import java.util.logging.Logger
 import com.example.myrecipes.R
 import com.example.myrecipes.model.database.Recipes.Recipe
 
 @Composable
-fun RecipeDetail(modelViewModel: RecipesListViewModel) {
+fun RecipeDetail(modelViewModel: RecipesListViewModel, recipeId: String) {
     val recipes = modelViewModel.recipes.collectAsState()
     val logger = Logger.getLogger("MyLogger")
     val img = R.drawable.carlo
     val recipe = recipes.value
-    val currentRecipe = recipe[0]
+    val currentRecipe = modelViewModel.getRecipeById(recipeId)
     val scrollState = rememberScrollState()
 
-    Box(modifier = Modifier
-        .fillMaxSize()
-        .padding(10.dp)
-        .background(color = Color.White)
-        .verticalScroll(scrollState)) {
+    if (currentRecipe == null) {
+        // Display an error message if no currentRecipe is found
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("Recipe not found", style = MaterialTheme.typography.h6, color = Color.Red)
+        }
+        return
+    }
 
+    // Continue with the normal ui for showing recipe details.
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(10.dp)
+            .background(color = Color.White)
+            .verticalScroll(scrollState)
+    ) {
 
         Column(
             modifier = Modifier
@@ -52,8 +71,7 @@ fun RecipeDetail(modelViewModel: RecipesListViewModel) {
                 .background(color = Color.White)
         ) {
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
+                modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center
             ) {
                 Text(
                     text = currentRecipe.strMeal,
@@ -64,14 +82,14 @@ fun RecipeDetail(modelViewModel: RecipesListViewModel) {
             }
 
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center
+                modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center
             ) {
                 Image(
-                    painter = painterResource(img),
+                    painter = rememberImagePainter(data = currentRecipe.strMealThumb),
                     contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth()
+                        .size(300.dp)
+                        .padding(20.dp)
                 )
             }
 
@@ -83,7 +101,7 @@ fun RecipeDetail(modelViewModel: RecipesListViewModel) {
 }
 
 @Composable
-fun RecipeIngredients(recipe: Recipe){
+fun RecipeIngredients(recipe: Recipe) {
     val ingredientMap = mutableMapOf<String, String>()
     for (i in 1..20) {
         val ingredient = recipe.getIngredient(i)
@@ -92,30 +110,31 @@ fun RecipeIngredients(recipe: Recipe){
             ingredientMap[ingredient] = measure
         }
     }
-    Text(text = "Ingredident",
-        fontSize = 24.sp)
+    Text(
+        text = "Ingredident", fontSize = 24.sp
+    )
     Spacer(modifier = Modifier.height(16.dp))
     ingredientMap.forEach { (ingredient, measure) ->
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
+            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(text = ingredient)
             Text(text = measure)
         }
     }
 }
+
 @Composable
-fun RecipeDirections(recipe: Recipe){
+fun RecipeDirections(recipe: Recipe) {
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
-        Text(text = "Directions",
-                fontSize = 24.sp)
+        Text(
+            text = "Directions", fontSize = 24.sp
+        )
         Spacer(modifier = Modifier.height(16.dp))
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center
+            modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center
         ) {
             Text(text = recipe.strInstructions)
         }

--- a/app/src/main/java/com/example/myrecipes/view/UI/RecipesList.kt
+++ b/app/src/main/java/com/example/myrecipes/view/UI/RecipesList.kt
@@ -2,6 +2,7 @@ package com.example.myrecipes.view.UI
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,13 +31,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import coil.compose.rememberImagePainter
 import com.example.myrecipes.R
 import com.example.myrecipes.model.database.Recipes.Recipe
 import com.example.myrecipes.modelview.RecipesListViewModel
+import com.example.myrecipes.view.navigation.NavigationItem
 
 @Composable
-fun RecipesList(modelViewModel: RecipesListViewModel) {
+fun RecipesList(modelViewModel: RecipesListViewModel, navController: NavController) {
     val productsState = modelViewModel.recipes.collectAsState()
     val loadingState = modelViewModel.loading.collectAsState()
     val errorState = modelViewModel.error.collectAsState()
@@ -70,13 +73,15 @@ fun RecipesList(modelViewModel: RecipesListViewModel) {
             }
 
             else -> {
-                // Display the list of recipes
                 Column(
-                    modifier = Modifier
-                        .verticalScroll(rememberScrollState())
+                    modifier = Modifier.verticalScroll(rememberScrollState())
                 ) {
                     products.forEach { recipe ->
-                        RecipeCard(recipe = recipe)  // Assuming RecipeCard is a Composable that represents a single recipe item
+                        RecipeCard(recipe = recipe) {
+                            val route =
+                                NavigationItem.RecipeDetail.createRoute(recipeId = recipe.idMeal)
+                            navController.navigate(route)
+                        }
                     }
                 }
             }
@@ -86,12 +91,13 @@ fun RecipesList(modelViewModel: RecipesListViewModel) {
 }
 
 @Composable
-fun RecipeCard(recipe: Recipe) {
+fun RecipeCard(recipe: Recipe, onClickHandler: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(10.dp)
             .background(Color.LightGray)
+            .clickable { onClickHandler() }
     ) {
         Image(
             painter = rememberImagePainter(data = recipe.strMealThumb),
@@ -107,8 +113,7 @@ fun RecipeCard(recipe: Recipe) {
                 .align(Alignment.Top)
         ) {
             Text(
-                text = recipe.strMeal,
-                style = MaterialTheme.typography.h6
+                text = recipe.strMeal, style = MaterialTheme.typography.h6
             )
             Text(
                 text = "Category: ${recipe.strCategory}",
@@ -144,8 +149,7 @@ fun LoadingStatePreview() {
 fun ErrorStatePreview() {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .fillMaxSize()  // This makes the Box fill the entire available space in the preview
+        modifier = Modifier.fillMaxSize()  // This makes the Box fill the entire available space in the preview
     ) {
         Text(
             "An error occurred, please try again",
@@ -221,8 +225,7 @@ fun RecipeCardPreview() {
                     .align(Alignment.Top)
             ) {
                 Text(
-                    text = recipe.strMeal,
-                    style = MaterialTheme.typography.h6
+                    text = recipe.strMeal, style = MaterialTheme.typography.h6
                 )
                 Text(
                     text = "Category: ${recipe.strCategory}",

--- a/app/src/main/java/com/example/myrecipes/view/UI/RecipesList.kt
+++ b/app/src/main/java/com/example/myrecipes/view/UI/RecipesList.kt
@@ -1,7 +1,38 @@
 package com.example.myrecipes.view.UI
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.rememberImagePainter
+import com.example.myrecipes.R
+import com.example.myrecipes.model.database.Recipes.Recipe
 import com.example.myrecipes.modelview.RecipesListViewModel
 
 @Composable
@@ -11,9 +42,199 @@ fun RecipesList(modelViewModel: RecipesListViewModel) {
     val errorState = modelViewModel.error.collectAsState()
     val pageState = modelViewModel.page.collectAsState()
 
-
     // Access the values
     val products = productsState.value
     val isLoading = loadingState.value
     val isError = errorState.value
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        when {
+            isLoading -> {
+                // Display loading indicator
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+
+            isError -> {
+                // Display error message
+                Text(
+                    "An error occurred, please try again",
+                    color = Color.Red,
+                    fontSize = 18.sp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+
+            else -> {
+                // Display the list of recipes
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    products.forEach { recipe ->
+                        RecipeCard(recipe = recipe)  // Assuming RecipeCard is a Composable that represents a single recipe item
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+@Composable
+fun RecipeCard(recipe: Recipe) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(10.dp)
+            .background(Color.LightGray)
+    ) {
+        Image(
+            painter = rememberImagePainter(data = recipe.strMealThumb),
+            contentDescription = "Recipe Image",
+            modifier = Modifier
+                .size(100.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .padding(10.dp)
+        )
+        Column(
+            modifier = Modifier
+                .padding(start = 2.dp, top = 10.dp)
+                .align(Alignment.Top)
+        ) {
+            Text(
+                text = recipe.strMeal,
+                style = MaterialTheme.typography.h6
+            )
+            Text(
+                text = "Category: ${recipe.strCategory}",
+                style = MaterialTheme.typography.body2,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+            Text(
+                text = "Tags: ${recipe.strTags}",
+                style = MaterialTheme.typography.body2,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun LoadingStatePreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(10.dp)
+            .background(Color.White)
+    ) {
+        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+    }
+
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun ErrorStatePreview() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxSize()  // This makes the Box fill the entire available space in the preview
+    ) {
+        Text(
+            "An error occurred, please try again",
+            color = Color.Red,
+            fontSize = 18.sp,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+
+@Preview
+@Composable
+fun RecipeCardPreview() {
+    val recipe = Recipe(
+        idMeal = "12345",
+        strMeal = "Sample Recipe Name",
+        strDrinkAlternate = null, // Nullable field
+        strCategory = "Dessert",
+        strArea = "International",
+        strInstructions = "Mix all ingredients and bake for 45 minutes at 350 degrees.",
+        strMealThumb = "file:///android_res/drawable/your_placeholder_image.png",
+        strTags = "Easy, Quick",
+        strYoutube = "https://youtube.com/samplevideo",
+        strIngredient1 = "Flour",
+        strIngredient2 = "Sugar",
+        strIngredient3 = "Eggs",
+        strIngredient4 = "Butter",
+        strIngredient5 = "Baking Soda",
+        strIngredient6 = "Salt",
+        strIngredient7 = "Vanilla Extract",
+        strIngredient8 = "Milk",
+        strIngredient9 = "Cocoa Powder",
+        strIngredient10 = "Chocolate Chips",
+        strMeasure1 = "1 Cup",
+        strMeasure2 = "200g",
+        strMeasure3 = "3 Large",
+        strMeasure4 = "100g",
+        strMeasure5 = "1 Tsp",
+        strMeasure6 = "1 Tsp",
+        strMeasure7 = "2 Tsp",
+        strMeasure8 = "200ml",
+        strMeasure9 = "50g",
+        strMeasure10 = "100g",
+        strSource = "https://www.samplewebsite.com/recipes/sample-recipe-name",
+        strImageSource = null, // Nullable field
+        strCreativeCommonsConfirmed = null, // Nullable field
+        dateModified = null // Nullable field
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp)
+                .background(Color.LightGray)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.carlo),
+                contentDescription = "Recipe Image",
+                modifier = Modifier
+                    .size(100.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .padding(10.dp)
+            )
+            Column(
+                modifier = Modifier
+                    .padding(start = 2.dp, top = 10.dp)
+                    .align(Alignment.Top)
+            ) {
+                Text(
+                    text = recipe.strMeal,
+                    style = MaterialTheme.typography.h6
+                )
+                Text(
+                    text = "Category: ${recipe.strCategory}",
+                    style = MaterialTheme.typography.body2,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+                Text(
+                    text = "Tags: ${recipe.strTags}",
+                    style = MaterialTheme.typography.body2,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/example/myrecipes/view/navigation/AppHost.kt
+++ b/app/src/main/java/com/example/myrecipes/view/navigation/AppHost.kt
@@ -5,8 +5,10 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import androidx.work.WorkManager
 import com.example.myrecipes.modelview.RecipesListViewModel
 import com.example.myrecipes.view.UI.Home
@@ -20,8 +22,8 @@ fun AppNavHost(
     navController: NavHostController,
     context: Context,
     application: Application,
-    workManager: WorkManager)
-{
+    workManager: WorkManager
+) {
     NavHost(
         modifier = modifier,
         navController = navController,
@@ -33,15 +35,21 @@ fun AppNavHost(
             Home(modelViewModel = recipeListViewModel, navController = navController)
         }
         composable(NavigationItem.Login.route) {
-            
+
         }
         composable(NavigationItem.Signup.route) {
         }
         composable(NavigationItem.RecipeList.route) {
-            RecipesList(modelViewModel = recipeListViewModel)
+            RecipesList(modelViewModel = recipeListViewModel, navController = navController)
         }
-        composable(NavigationItem.RecipeDetail.route) {
-            RecipeDetail(modelViewModel = recipeListViewModel)
+        composable(NavigationItem.RecipeDetail.route,
+            arguments = listOf(navArgument("recipeId") { type = NavType.StringType })
+        ) {
+            val recipeId = it.arguments?.getString("recipeId")
+            if (recipeId != null) {
+                // There needs to be a valid existing recipeId to access this route
+                RecipeDetail(modelViewModel = recipeListViewModel, recipeId = recipeId)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/myrecipes/view/navigation/AppHost.kt
+++ b/app/src/main/java/com/example/myrecipes/view/navigation/AppHost.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkManager
 import com.example.myrecipes.modelview.RecipesListViewModel
 import com.example.myrecipes.view.UI.Home
 import com.example.myrecipes.view.UI.RecipeDetail
+import com.example.myrecipes.view.UI.RecipesList
 
 
 @Composable
@@ -37,6 +38,7 @@ fun AppNavHost(
         composable(NavigationItem.Signup.route) {
         }
         composable(NavigationItem.RecipeList.route) {
+            RecipesList(modelViewModel = recipeListViewModel)
         }
         composable(NavigationItem.RecipeDetail.route) {
             RecipeDetail(modelViewModel = recipeListViewModel)

--- a/app/src/main/java/com/example/myrecipes/view/navigation/Routes.kt
+++ b/app/src/main/java/com/example/myrecipes/view/navigation/Routes.kt
@@ -1,18 +1,18 @@
 package com.example.myrecipes.view.navigation
 
-enum class Screen {
-    HOME_SCREEN,
-    LOGIN,
-    SIGNUP,
-    RECIPE_LIST,
-    RECIPE_DETAIL
+enum class Screen(val route: String) {
+    HOME_SCREEN("homeScreen"),
+    LOGIN("login"),
+    SIGNUP("signup"),
+    RECIPE_LIST("recipeList"),
+    RECIPE_DETAIL("recipeDetail/{recipeId}")
 }
 sealed class NavigationItem(val route: String) {
 
-    object Home : NavigationItem(Screen.HOME_SCREEN.name)
-    object Login : NavigationItem(Screen.LOGIN.name)
-    object Signup : NavigationItem(Screen.SIGNUP.name)
-    object RecipeList : NavigationItem(Screen.RECIPE_LIST.name)
-    object RecipeDetail : NavigationItem(Screen.RECIPE_DETAIL.name)
+    object Home : NavigationItem(Screen.HOME_SCREEN.route)
+    object Login : NavigationItem(Screen.LOGIN.route)
+    object Signup : NavigationItem(Screen.SIGNUP.route)
+    object RecipeList : NavigationItem(Screen.RECIPE_LIST.route)
+    object RecipeDetail : NavigationItem(Screen.RECIPE_DETAIL.route)
 
 }

--- a/app/src/main/java/com/example/myrecipes/view/navigation/Routes.kt
+++ b/app/src/main/java/com/example/myrecipes/view/navigation/Routes.kt
@@ -13,6 +13,8 @@ sealed class NavigationItem(val route: String) {
     object Login : NavigationItem(Screen.LOGIN.route)
     object Signup : NavigationItem(Screen.SIGNUP.route)
     object RecipeList : NavigationItem(Screen.RECIPE_LIST.route)
-    object RecipeDetail : NavigationItem(Screen.RECIPE_DETAIL.route)
+    object RecipeDetail : NavigationItem(Screen.RECIPE_DETAIL.route) {
+        fun createRoute(recipeId: String) = "recipeDetail/$recipeId"
+    }
 
 }


### PR DESCRIPTION
Some significant changes were made to our routing system. I changed the Routes.kt to include a (route: string) parameter so that the RecipeList can call the navcontroller to go to the RecipeDetails page with the given recipeId that the user clicked on.

The RecipeDetail page uses the RecipeListViewModel as well.

the RecipeDetail page will use the modelViewModel.getRecipeById(recipeId) to find the current page.